### PR TITLE
Add .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ coverage/
 doc/
 dist/
 .tern-port
+.DS_Store


### PR DESCRIPTION
When I tried to create documentation locally on my Mac using `grunt jsdoc` a new folder was added: `.DS_Store`. Just to be sure I won't happen to add it to the git repository, I want add it to the .gitignore file. 
